### PR TITLE
Update to handle changes in Unity Cloud webhooks

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -28,6 +28,8 @@ router.post('/build', function*(next) {
   console.info(`Unity Cloud: Build Recieved`);
   console.info(`Project: ${projectName} target: ${target}`);
 
+  console.info(this.request.body);
+
   let targets = projects.find(uuid, target);
   let queuedBuilds = 0;
   let failedBuilds = 0;

--- a/src/server.js
+++ b/src/server.js
@@ -32,25 +32,31 @@ router.post('/build', function*(next) {
   let queuedBuilds = 0;
   let failedBuilds = 0;
 
-  // attempt to find the artifact for this project
-  let buildData = yield unitycloudapi.processLink(this.request.body.links.api_self);
-  let buildProperties = { unityCloudArtifactUrl: JSON.parse(buildData.body).links.download_primary.href };
+  try {
+    // The primary artifact will have the value primary: true
+    const primaryArtifact = this.request.body.links.artifacts.find(artifact => artifact.primary);
+    const artifactURL = primaryArtifact.files[0].href;
 
-  while (targets.length > 0) {
-    let target = targets.shift();
-    let response = yield teamcityapi.createBuild(target.teamcity_id, buildNumber, buildProperties);
+    while (targets.length > 0) {
+      let target = targets.shift();
+      let response = yield teamcityapi.createBuild(target.teamcity_id, buildNumber, { remoteArtifactURL: artifactURL });
 
-    // Todo move this into the teamcity-api to handle
-    if (response.statusCode < 200 || response.statusCode >= 400) {
-      failedBuilds++;
-      console.error(`Team City: Responded with Error ${response.statusCode} ${response.statusMessage}`);
-      console.error(response.body);
-    } else {
-      queuedBuilds++;
+      // Todo move this into the teamcity-api to handle
+      if (response.statusCode < 200 || response.statusCode >= 400) {
+        failedBuilds++;
+        console.error(`Team City: Responded with Error ${response.statusCode} ${response.statusMessage}`);
+        console.error(response.body);
+      } else {
+        queuedBuilds++;
 
-      let buildDetails = JSON.parse(response.body).buildType;
-      console.log(`Team City: Build ${buildDetails.projectName} , ${buildDetails.name} #${buildNumber} queued`);
+        let buildDetails = JSON.parse(response.body).buildType;
+        console.log(`Team City: Build ${buildDetails.projectName} , ${buildDetails.name} #${buildNumber} queued`);
+      }
     }
+  } catch (err) {
+    console.error(`Unity Cloud: Failed to parse packet from unity cloud webhook, the API may have changed`);
+    console.error(err);
+    failedBuilds++
   }
 
   this.body = `Builds Queued:${queuedBuilds} Failed:${failedBuilds}`;


### PR DESCRIPTION
Updated to handle the changes to the payload from Unity Cloud's webhooks. Its worth noting that tests and a re-structure are on the way, because this started out as a hacked together project 2 years ago and now it needs dragging up to standard - this PR is not the place for pointing out those changes.

- Handles nested artifact links
- Added additional verbose log of the received payload